### PR TITLE
Add mergeDateAndTime to the utils so <calender /> can use it

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ declare class PersianUtils {
 
   public getYear(date: Moment): number;
   public setYear(date: Moment, year: number): Moment;
+  public mergeDateAndTime(date: Moment, time: Moment): Moment;
 
   public getDiff(date: Moment, comparing: Moment): number;
   public getWeekdays(): string[];

--- a/index.js
+++ b/index.js
@@ -138,6 +138,10 @@ Utils.prototype.setYear = function setYear(date, year) {
   return date.clone().jYear(year);
 };
 
+Utils.prototype.mergeDateAndTime = function mergeDateAndTime(date, time) {
+    return this.setMinutes(this.setHours(date, this.getHours(time)), this.getMinutes(time));
+};
+
 Utils.prototype.getDiff = function getDiff(date, comparing) {
   return date.diff(comparing);
 }


### PR DESCRIPTION
material-ui-pickers just released v1.0.0-rc.12 with a new mergeDateAndTime method that adds ability to more slightly control time selection
without this, <Calender /> is going to cause an exception error
